### PR TITLE
Fix hints and warnings

### DIFF
--- a/sources/Redis.Client.pas
+++ b/sources/Redis.Client.pas
@@ -36,7 +36,7 @@ type
   protected
     procedure Connect;
     function GetCmdList(const Cmd: string): IRedisCommand;
-    function NextToken(out Msg: String): boolean;
+    procedure NextToken(out Msg: String);
     function NextBytes(const ACount: UInt32): TBytes;
     /// //
     function InternalBlockingLeftOrRightPOP(NextCMD: IRedisCommand;
@@ -181,8 +181,6 @@ begin
 end;
 
 procedure TRedisClient.ClientSetName(const ClientName: String);
-var
-  R: string;
 begin
   NextCMD := GetCmdList('CLIENT');
   NextCMD.Add('SETNAME');
@@ -516,7 +514,7 @@ begin
   end;
 end;
 
-function TRedisClient.NextToken(out Msg: String): boolean;
+procedure TRedisClient.NextToken(out Msg: String);
 begin
   Msg := FTCPLibInstance.Receive(FCommandTimeout);
   FIsTimeout := FTCPLibInstance.LastReadWasTimedOut;
@@ -571,12 +569,12 @@ var
   R: string;
   I: Integer;
 begin
+  Result := -1;
   if FInTransaction then
   begin
     R := ParseSimpleStringResponse(FValidResponse);
     if R <> 'QUEUED' then
       raise ERedisException.Create(R);
-    Result := -1;
     Exit;
   end;
 

--- a/sources/Redis.Command.pas
+++ b/sources/Redis.Command.pas
@@ -9,7 +9,6 @@ type
   TRedisCommand = class(TRedisClientBase, IRedisCommand)
   private
     FCommandIsSet: Boolean;
-    function GetBinaryRedisToken(const Index: Integer): TBytes;
   protected
     FParts: TList<TBytes>;
 
@@ -74,13 +73,6 @@ destructor TRedisCommand.Destroy;
 begin
   FParts.Free;
   inherited;
-end;
-
-function TRedisCommand.GetBinaryRedisToken(
-  const
-  Index:
-  Integer): TBytes;
-begin
 end;
 
 function TRedisCommand.GetToken(

--- a/tests/TestRedisClientU.pas
+++ b/tests/TestRedisClientU.pas
@@ -217,7 +217,6 @@ procedure TestRedisClient.TestHMSetHMGet;
 const
   C_KEY = 'thekey';
 var
-  aResult: string;
   lValues: TArray<String>;
 begin
   FRedis.DEL([C_KEY]);


### PR DESCRIPTION
We have a 0 hints/warnings policy in our builds and these hints and warnings were breaking it:

```
Redis.Command.pas(12) Hint: H2219 Private symbol 'GetBinaryRedisToken' declared but never used
Redis.Client.pas(185) Hint: H2164 Variable 'R' is declared but never used in 'TRedisClient.ClientSetName'
Redis.Client.pas(523) Warning: W1035 Return value of function 'TRedisClient.NextToken' might be undefined
Redis.Client.pas(585) Warning: W1035 Return value of function 'TRedisClient.ParseIntegerResponse' might be undefined
```

These changes removes all the hints and warnings. All the tests still pass.
