### PR TITLE
Fix EVAL issue where args wouldn't be added unless keys were also present

### DIFF
--- a/sources/Redis.Client.pas
+++ b/sources/Redis.Client.pas
@@ -435,10 +435,11 @@ begin
     begin
       lCmd.Add(lPar);
     end;
-    for lPar in AValues do
-    begin
-      lCmd.Add(lPar);
-    end;
+  end;
+  
+  for lPar in AValues do
+  begin
+    lCmd.Add(lPar);
   end;
 
   Result := ExecuteWithIntegerResult(lCmd);


### PR DESCRIPTION
Script args are not dependent on keys being present.