### PR TITLE
Fix SSL issue in latest Indy versions by setting PassThrough to False

### DIFF
--- a/sources/Redis.NetLib.INDY.pas
+++ b/sources/Redis.NetLib.INDY.pas
@@ -39,6 +39,7 @@ begin
   if AUseSSL then
   begin
     FTCPClient.IOHandler := TIdSSLIOHandlerSocketOpenSSL.Create(FTCPClient);
+    (FTCPClient.IOHandler as TIdSSLIOHandlerSocketOpenSSL).PassThrough := False;
   end;
 
   FTCPClient.Connect(HostName, Port);


### PR DESCRIPTION
In late-2019, Indy changed the default value of TIdSSLIOHandlerSocketBase.PassThrough to True.
As a consequence, DelphiRedisClient with UseSSL will still send unencrypted traffic if used with the latest Indy.

See:
* https://github.com/IndySockets/Indy/commit/d54269ed3817e4d29023673aa3d78781ac826465
* https://community.idera.com/developer-tools/data-internet-and-web-services/f/internet-clients/72775/how-to-fix-delphi-10-4-problem-with-indy-tidtcpclient-and-encrypted-connections