### PR TITLE
Fix EVAL issue where args are only used when keys are present

### DIFF
--- a/sources/Redis.Client.pas
+++ b/sources/Redis.Client.pas
@@ -559,10 +559,11 @@ begin
     begin
       lCmd.Add(lPar);
     end;
-    for lPar in aValues do
-    begin
-      lCmd.Add(lPar);
-    end;
+  end;
+  
+  for lPar in aValues do
+  begin
+    lCmd.Add(lPar);
   end;
 
   Result := ExecuteWithIntegerResult(lCmd);


### PR DESCRIPTION
Script args are not dependent on keys being present.