### PR TITLE
HSETNX call

### DIFF
--- a/sources/Redis.Client.pas
+++ b/sources/Redis.Client.pas
@@ -121,6 +121,10 @@ type
     // hash
     function HSET(const aKey, aField: string; aValue: string): Integer; overload;
     function HSET(const aKey, aField: string; aValue: TBytes): Integer; overload;
+    function HSETNX(const aKey, aField: string; aValue: string): Boolean; overload;
+    function HSETNX(const aKey, aField: string; aValue: TBytes): Boolean; overload;
+
+
     procedure HMSET(const aKey: string; aFields: TArray<string>; aValues: TArray<string>); overload;
     procedure HMSET(const aKey: string; aFields: TArray<string>; aValues: TArray<TBytes>); overload;
     function HMGET(const aKey: string; aFields: TArray<string>): TRedisArray;
@@ -874,6 +878,23 @@ begin
   FNextCMD.Add(aValue);
   FTCPLibInstance.SendCmd(FNextCMD);
   Result := ParseIntegerResponse(FValidResponse);
+end;
+
+function TRedisClient.HSETNX(const aKey, aField: string;
+  aValue: TBytes): Boolean;
+begin
+  FNextCMD := GetCmdList('HSETNX');
+  FNextCMD.Add(aKey);
+  FNextCMD.Add(aField);
+  FNextCMD.Add(aValue);
+  FTCPLibInstance.SendCmd(FNextCMD);
+  Result := ParseIntegerResponse(FValidResponse) = 1;
+end;
+
+function TRedisClient.HSETNX(const aKey, aField: string;
+  aValue: string): Boolean;
+begin
+  Result := HSETNX(aKey, aField,BytesOfUnicode(aValue));
 end;
 
 function TRedisClient.HVALS(const aKey: string): TRedisArray;

--- a/sources/Redis.Commons.pas
+++ b/sources/Redis.Commons.pas
@@ -118,6 +118,8 @@ type
     procedure HMSET(const aKey: string; aFields: TArray<string>; aValues: TArray<string>); overload;
     procedure HMSET(const aKey: string; aFields: TArray<string>; aValues: TArray<TBytes>); overload;
     function HSET(const aKey, aField: string; aValue: TBytes): Integer; overload;
+    function HSETNX(const aKey, aField: string; aValue: TBytes): Boolean; overload;
+    function HSETNX(const aKey, aField: string; aValue: string): Boolean; overload;
     function HGET(const aKey, aField: string; out aValue: TBytes): boolean; overload;
     function HGET(const aKey, aField: string; out aValue: string): boolean; overload;
     function HGET_AsBytes(const aKey, aField: string): TRedisBytes;


### PR DESCRIPTION
Available since:
2.0.0

Sets field in the hash stored at key to value, only if field does not yet exist. If key does not exist, a new key holding a hash is created. If field already exists, this operation has no effect.

https://redis.io/docs/latest/commands/hsetnx/