### PR TITLE
Make default encoding consistent across different platforms.

### DIFF
--- a/sources/Redis.Commons.pas
+++ b/sources/Redis.Commons.pas
@@ -67,6 +67,8 @@ type
 
   TRedisClientBase = class abstract(TInterfacedObject)
   protected
+    function BytesOf(const Val: string): TBytes;
+    function StringOf(const Bytes: TBytes): string;
     function BytesOfUnicode(const AUnicodeString: string): TBytes;
     function StringOfUnicode(const ABytes: TBytes): string;
   end;
@@ -331,6 +333,16 @@ end;
 function TRedisClientBase.StringOfUnicode(const ABytes: TBytes): string;
 begin
   Result := StringOf(ABytes);
+end;
+
+function TRedisClientBase.BytesOf(const Val: string): TBytes;
+begin
+  Result := TEncoding.UTF8.GetBytes(Val);
+end;
+
+function TRedisClientBase.StringOf(const Bytes: TBytes): string;
+begin
+  Result := TEncoding.UTF8.GetString(Bytes);
 end;
 
 end.

--- a/tests/TestRedisClientU.pas
+++ b/tests/TestRedisClientU.pas
@@ -1237,6 +1237,7 @@ end;
 procedure TestRedisClient.TestSetGet;
 var
   Res: string;
+  Expected: String;
 begin
 
 {$WARN SYMBOL_DEPRECATED OFF}
@@ -1254,6 +1255,11 @@ begin
   CheckTrue(FRedis.&SET('no"me', 'Dan iele'));
   CheckTrue(FRedis.GET('no"me', Res));
   CheckEquals('Dan iele', Res);
+
+  Expected := #$C2' stray character';
+  CheckTrue(FRedis.&SET('value', TEncoding.UTF8.GetBytes(Expected)));
+  CheckTrue(FRedis.GET('value', Res));
+  CheckEquals(Expected, Res);
 end;
 
 procedure TestRedisClient.TestSetGetUnicode;


### PR DESCRIPTION
Windows clients default to ANSI but Linux clients default to UTF-8. 
Change the default encoding to UTF-8 for all platforms.
Fixes https://github.com/danieleteti/delphiredisclient/issues/43