### PR TITLE
Feature/isconnected

### DIFF
--- a/docs/plans/2026-03-07-isconnected-design.md
+++ b/docs/plans/2026-03-07-isconnected-design.md
@@ -1,0 +1,56 @@
+# Design: IsConnected property for TRedisClient
+
+## Problem
+
+`NewRedisClient()` calls `.Connect` automatically, but there is no way to check
+whether the connection is still active. Consumers holding an `IRedisClient`
+reference cannot determine if the client has been connected or if the connection
+is still alive after some time has passed.
+
+## Solution
+
+Add two `IsConnected` overloads to `IRedisClient` and implement them in
+`TRedisClient`:
+
+```delphi
+function IsConnected: Boolean; overload;
+function IsConnected(const aVerifyConnection: Boolean): Boolean; overload;
+```
+
+- `IsConnected` returns a simple boolean flag (no network call).
+- `IsConnected(True)` additionally sends a `PING` to verify the connection is
+  alive. If the PING fails, the flag is set to `False`.
+
+## Changes
+
+### Redis.Commons.pas - IRedisClient interface
+
+Add after `procedure Disconnect;`:
+
+```delphi
+function IsConnected: Boolean; overload;
+function IsConnected(const aVerifyConnection: Boolean): Boolean; overload;
+```
+
+### Redis.Client.pas - TRedisClient class
+
+1. Add private field `FIsConnected: Boolean`.
+2. Set `FIsConnected := True` at the end of `Connect`.
+3. Set `FIsConnected := False` at the start of `Disconnect`.
+4. Implement both `IsConnected` overloads.
+
+The verified variant tries `PING` inside a try/except. On any exception it sets
+`FIsConnected := False` and returns `False`.
+
+### Tests
+
+Add a test that creates a client, checks `IsConnected` returns `True`, then
+disconnects and checks it returns `False`.
+
+## Rejected alternatives
+
+- **Ping in the constructor**: `NewRedisClient` already raises
+  `ERedisConnectionException` on failure, so pinging at construction adds no
+  value. The real use case is checking liveness later.
+- **Always ping**: Too expensive for the common case where you just need to know
+  if `Connect` was called.

--- a/docs/plans/2026-03-07-isconnected-plan.md
+++ b/docs/plans/2026-03-07-isconnected-plan.md
@@ -1,0 +1,213 @@
+# IsConnected Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `IsConnected` to `IRedisClient` so consumers can check connection state, with an optional PING-based liveness verification.
+
+**Architecture:** A boolean field `FIsConnected` tracks state, set in `Connect`/`Disconnect`. Two overloads: parameterless returns the flag; with `aVerifyConnection = True` sends a PING and updates the flag on failure.
+
+**Tech Stack:** Delphi, DUnit (existing test framework in `tests/TestRedisClientU.pas`)
+
+---
+
+### Task 1: Create feature branch
+
+**Step 1: Create and switch to feature branch**
+
+Run: `git checkout -b feature/isconnected`
+
+**Step 2: Verify branch**
+
+Run: `git branch --show-current`
+Expected: `feature/isconnected`
+
+---
+
+### Task 2: Add IsConnected to IRedisClient interface
+
+**Files:**
+- Modify: `sources/Redis.Commons.pas:338` (after `procedure Disconnect;`)
+
+**Step 1: Add overloads to IRedisClient**
+
+In `sources/Redis.Commons.pas`, after line 338 (`procedure Disconnect;`), add:
+
+```delphi
+    function IsConnected: Boolean; overload;
+    function IsConnected(const aVerifyConnection: Boolean): Boolean; overload;
+```
+
+The result at lines 337-341 should look like:
+
+```delphi
+    procedure Connect;
+    procedure Disconnect;
+    function IsConnected: Boolean; overload;
+    function IsConnected(const aVerifyConnection: Boolean): Boolean; overload;
+    function InTransaction: boolean;
+```
+
+**Step 2: Commit**
+
+```bash
+git add sources/Redis.Commons.pas
+git commit -m "Add IsConnected overloads to IRedisClient interface"
+```
+
+---
+
+### Task 3: Add FIsConnected field and class declarations to TRedisClient
+
+**Files:**
+- Modify: `sources/Redis.Client.pas:46` (private section, after `FIsTimeout`)
+- Modify: `sources/Redis.Client.pas:278` (public section, after `Disconnect`)
+
+**Step 1: Add private field**
+
+In `sources/Redis.Client.pas`, after line 46 (`FIsTimeout: boolean;`), add:
+
+```delphi
+    FIsConnected: boolean;
+```
+
+**Step 2: Add public method declarations**
+
+In `sources/Redis.Client.pas`, after line 278 (`procedure Disconnect;`), add:
+
+```delphi
+    function IsConnected: Boolean; overload;
+    function IsConnected(const aVerifyConnection: Boolean): Boolean; overload;
+```
+
+**Step 3: Commit**
+
+```bash
+git add sources/Redis.Client.pas
+git commit -m "Add FIsConnected field and IsConnected declarations to TRedisClient"
+```
+
+---
+
+### Task 4: Implement IsConnected and update Connect/Disconnect
+
+**Files:**
+- Modify: `sources/Redis.Client.pas` (Connect, Disconnect, new implementations)
+
+**Step 1: Update Connect to set FIsConnected**
+
+In `sources/Redis.Client.pas`, the `Connect` procedure (line 462-465) should become:
+
+```delphi
+procedure TRedisClient.Connect;
+begin
+  FTCPLibInstance.Connect(FHostName, FPort);
+  FIsConnected := True;
+end;
+```
+
+**Step 2: Update Disconnect to clear FIsConnected**
+
+In `sources/Redis.Client.pas`, the `Disconnect` procedure (line 513-519) should become:
+
+```delphi
+procedure TRedisClient.Disconnect;
+begin
+  try
+    FIsConnected := False;
+    FTCPLibInstance.Disconnect;
+  except
+  end;
+end;
+```
+
+**Step 3: Add IsConnected implementations**
+
+Add the two implementations near the `Connect`/`Disconnect` methods (after `Disconnect`):
+
+```delphi
+function TRedisClient.IsConnected: Boolean;
+begin
+  Result := FIsConnected;
+end;
+
+function TRedisClient.IsConnected(const aVerifyConnection: Boolean): Boolean;
+begin
+  if aVerifyConnection and FIsConnected then
+  begin
+    try
+      PING;
+    except
+      FIsConnected := False;
+    end;
+  end;
+  Result := FIsConnected;
+end;
+```
+
+**Step 4: Commit**
+
+```bash
+git add sources/Redis.Client.pas
+git commit -m "Implement IsConnected with optional PING verification"
+```
+
+---
+
+### Task 5: Add tests
+
+**Files:**
+- Modify: `tests/TestRedisClientU.pas`
+
+**Step 1: Add test method declarations**
+
+In the `published` section of `TestRedisClient` class, add:
+
+```delphi
+    procedure TestIsConnected;
+    procedure TestIsConnectedAfterDisconnect;
+```
+
+**Step 2: Implement tests**
+
+Add in the implementation section:
+
+```delphi
+procedure TestRedisClient.TestIsConnected;
+begin
+  CheckTrue(FRedis.IsConnected, 'IsConnected should be True after Connect');
+  CheckTrue(FRedis.IsConnected(False), 'IsConnected(False) should be True after Connect');
+  CheckTrue(FRedis.IsConnected(True), 'IsConnected(True) with PING should be True for active connection');
+end;
+
+procedure TestRedisClient.TestIsConnectedAfterDisconnect;
+begin
+  CheckTrue(FRedis.IsConnected, 'IsConnected should be True before Disconnect');
+  FRedis.Disconnect;
+  CheckFalse(FRedis.IsConnected, 'IsConnected should be False after Disconnect');
+  CheckFalse(FRedis.IsConnected(True), 'IsConnected(True) should be False after Disconnect');
+end;
+```
+
+**Step 3: Commit**
+
+```bash
+git add tests/TestRedisClientU.pas
+git commit -m "Add tests for IsConnected"
+```
+
+---
+
+### Task 6: Compile and verify
+
+**Step 1: Compile the test project using delphi-build MCP**
+
+Compile `tests/RedisClientTests.dpr` for Win64.
+
+**Step 2: Fix any compilation issues if needed**
+
+**Step 3: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "Fix compilation issues"
+```

--- a/sources/Redis.Client.pas
+++ b/sources/Redis.Client.pas
@@ -44,6 +44,7 @@ type
     FIsValidResponse: boolean;
     FInTransaction: boolean;
     FIsTimeout: boolean;
+    FIsConnected: boolean;
     FFormatSettings: TFormatSettings;
     function Redis_BytesToString(aValue: TRedisBytes): TRedisString;
     function ParseSimpleStringResponse(var AValidResponse: boolean): string;
@@ -276,6 +277,8 @@ type
     function ExecuteWithIntegerResult(const RedisCommand: IRedisCommand): Int64; overload;
     function ExecuteWithStringResult(const RedisCommand: IRedisCommand): TRedisString;
     procedure Disconnect;
+    function IsConnected: Boolean; overload;
+    function IsConnected(const aVerifyConnection: Boolean): Boolean; overload;
     procedure SetCommandTimeout(const Timeout: Int32);
     // client
     procedure ClientSetName(const ClientName: string);
@@ -462,6 +465,7 @@ end;
 procedure TRedisClient.Connect;
 begin
   FTCPLibInstance.Connect(FHostName, FPort);
+  FIsConnected := True;
 end;
 
 constructor TRedisClient.Create(const HostName: string; const Port: Word; const Lib: string);
@@ -513,9 +517,28 @@ end;
 procedure TRedisClient.Disconnect;
 begin
   try
+    FIsConnected := False;
     FTCPLibInstance.Disconnect;
   except
   end;
+end;
+
+function TRedisClient.IsConnected: Boolean;
+begin
+  Result := FIsConnected;
+end;
+
+function TRedisClient.IsConnected(const aVerifyConnection: Boolean): Boolean;
+begin
+  if aVerifyConnection and FIsConnected then
+  begin
+    try
+      PING;
+    except
+      FIsConnected := False;
+    end;
+  end;
+  Result := FIsConnected;
 end;
 
 function TRedisClient.ExecuteWithIntegerResult(const RedisCommand: IRedisCommand): Int64;

--- a/sources/Redis.Commons.pas
+++ b/sources/Redis.Commons.pas
@@ -336,6 +336,8 @@ type
     function Tokenize(const aRedisCommand: string): TArray<string>;
     procedure Connect;
     procedure Disconnect;
+    function IsConnected: Boolean; overload;
+    function IsConnected(const aVerifyConnection: Boolean): Boolean; overload;
     function InTransaction: boolean;
 
     // client

--- a/tests/TestRedisClientU.pas
+++ b/tests/TestRedisClientU.pas
@@ -135,6 +135,8 @@ type
     procedure TestGEORADIUS_WithDist;
     procedure TestGEORADIUS_Sorting;
     procedure TestGEORADIUS_Count;
+    procedure TestIsConnected;
+    procedure TestIsConnectedAfterDisconnect;
   end;
 
 implementation
@@ -1685,6 +1687,21 @@ begin
   FRedis.DEL(['set1', 'set2']);
   lRes := FRedis.SUNIONSTORE('dest', ['set1', 'set2']);
   CheckEquals(0, lRes);
+end;
+
+procedure TestRedisClient.TestIsConnected;
+begin
+  CheckTrue(FRedis.IsConnected, 'IsConnected should be True after Connect');
+  CheckTrue(FRedis.IsConnected(False), 'IsConnected(False) should be True after Connect');
+  CheckTrue(FRedis.IsConnected(True), 'IsConnected(True) with PING should be True for active connection');
+end;
+
+procedure TestRedisClient.TestIsConnectedAfterDisconnect;
+begin
+  CheckTrue(FRedis.IsConnected, 'IsConnected should be True before Disconnect');
+  FRedis.Disconnect;
+  CheckFalse(FRedis.IsConnected, 'IsConnected should be False after Disconnect');
+  CheckFalse(FRedis.IsConnected(True), 'IsConnected(True) should be False after Disconnect');
 end;
 
 initialization


### PR DESCRIPTION
# Summary

I've added an IsConnected method to IRedisClient so you can check whether your Redis connection is active.

There are two flavors:
- IsConnected -> just returns a boolean flag, no network call, super cheap
- IsConnected(True) -> same thing but also sends a PING to Redis to make sure the connection is actually alive. If the PING fails, it flips the flag to False

# Why

NewRedisClient() connects automatically, which is nice, but once you have the client reference there's no way to ask "am I still connected?" This matters when you hold onto a connection for a  while, maybe the server went down, maybe the network hiccuped. Right now you'd only find out when the next command blows up.

# What problem it solves

Any code that needs to check connection state before doing work, health checks, reconnection logic, connection pooling, can now do if Redis.IsConnected then ... instead of wrapping every call in try/except and hoping for the best. 

The optional PING verification covers the case where you need a real liveness check, not just "did I call Connect at some point."

# Modified units

- sources/Redis.Commons.pas: added IsConnected overloads to IRedisClient interface
- sources/Redis.Client.pas:  added FIsConnected field, implemented both overloads, updated Connect/Disconnect to track state

# Tests

- tests/TestRedisClientU.pas:  added TestIsConnected and TestIsConnectedAfterDisconnect
- Both tests passing, project compiles clean with zero errors and warnings